### PR TITLE
Using comma separated list of email addrs

### DIFF
--- a/src/common/email_util.js
+++ b/src/common/email_util.js
@@ -20,7 +20,7 @@ export function getEmailContent(tds) {
 }
 
 export function getMailToLink(tds) {
-  const address = getAddresses(tds).join(';\n');
+  const address = getAddresses(tds).join(',');
   const body = encodeURIComponent(
     `${getEmailContent(tds)}\n\nReference: https://d4hk.ie`
   );


### PR DESCRIPTION
According to stackoverflow.com/q/13765286, using semicolon to
separate email addresses in mailto link might cause issues in some
client. Comma should be the standard way to do so according to
tools.ietf.org/html/rfc6068.